### PR TITLE
Release capture from ports

### DIFF
--- a/ixnetwork_open_traffic_generator/ixnetworkapi.py
+++ b/ixnetwork_open_traffic_generator/ixnetworkapi.py
@@ -204,6 +204,10 @@ class IxNetworkApi(Api):
         payload = {'arg1': self._vport.href, 'arg2': file_id}
         response = self._request('POST', url, payload)
 
+        url = '%s/vport/operations/releaseCapturePorts' % self._ixnetwork.href
+        payload = {'arg1': [self._vport.href]}
+        response = self._request('POST', url, payload)
+
         path = '%s/capture' % self._ixnetwork.Globals.PersistencePath
         url = '%s/files?absolute=%s&filename=%s.cap' % (self._ixnetwork.href,
                                                         path, file_name)


### PR DESCRIPTION
Currently capture is not released from ports once capture has stopped or capture results have been retrieved.
This is an issue with limited functionality hardware where only a specific number of ports per card can be simultaneously used for capture. 

This PR frees up capture on ports once capture has been stopped.

