### PR TITLE
Handle PauseStatelessTraffic for stopped state

### DIFF
--- a/ixnetwork_open_traffic_generator/trafficitem.py
+++ b/ixnetwork_open_traffic_generator/trafficitem.py
@@ -554,14 +554,11 @@ class TrafficItem(CustomField):
         self._api._traffic_item.find(Name=regex)
         if len(self._api._traffic_item) > 0:
             if request.state == 'start':
-                self._api._traffic_item.find(Name=regex, State='^started$')
+                self._api._traffic_item.find(Name=regex, Suspend=True,
+                                             State='^started$')
                 if len(self._api._traffic_item) > 0:
                     with Timer(self._api, 'Flows resume'):
-                        try:
-                            self._api._traffic_item.PauseStatelessTraffic(False)
-                        except Exception:
-                            self._api.warning("Issue at the time to start pause traffic")
-                            self._api._traffic_item.StopStatelessTrafficBlocking()
+                        self._api._traffic_item.PauseStatelessTraffic(False)
                 self._api._traffic_item.find(Name=regex, State='^stopped$')
                 if len(self._api._traffic_item) > 0:
                     with Timer(self._api, 'Flows start'):

--- a/ixnetwork_open_traffic_generator/trafficitem.py
+++ b/ixnetwork_open_traffic_generator/trafficitem.py
@@ -539,6 +539,9 @@ class TrafficItem(CustomField):
                 with Timer(self._api, 'Devices start'):
                     self._api._ixnetwork.StartAllProtocols('sync')
                     self._api.check_protocol_statistics()
+            if len(self._api._traffic_item.find()) == 0:
+                return
+            self._api._traffic_item.find(State='^unapplied$')
             if len(self._api._traffic_item) > 0:
                 with Timer(self._api, 'Flows generate/apply'):
                     self._generate_flows_and_apply()
@@ -551,14 +554,18 @@ class TrafficItem(CustomField):
         self._api._traffic_item.find(Name=regex)
         if len(self._api._traffic_item) > 0:
             if request.state == 'start':
+                self._api._traffic_item.find(Name=regex, State='^started$')
+                if len(self._api._traffic_item) > 0:
+                    with Timer(self._api, 'Flows resume'):
+                        try:
+                            self._api._traffic_item.PauseStatelessTraffic(False)
+                        except Exception:
+                            self._api.warning("Issue at the time to start pause traffic")
+                            self._api._traffic_item.StopStatelessTrafficBlocking()
                 self._api._traffic_item.find(Name=regex, State='^stopped$')
                 if len(self._api._traffic_item) > 0:
                     with Timer(self._api, 'Flows start'):
                         self._api._traffic_item.StartStatelessTrafficBlocking()
-                self._api._traffic_item.find(Name=regex, State='^started$')
-                if len(self._api._traffic_item) > 0:
-                    with Timer(self._api, 'Flows resume'):
-                        self._api._traffic_item.PauseStatelessTraffic(False)
             elif request.state == 'stop':
                 self._api._traffic_item.find(Name=regex, State='^started$')
                 if len(self._api._traffic_item) > 0:


### PR DESCRIPTION
This PR probably handle this issue https://github.com/open-traffic-generator/ixnetwork/issues/356

As we are not able to reproduced this issue in house using OTG script. But we are suspecting some flow probably have very few duration. Therefore those flow are stop instantaneously. And we are trying to start using PauseStatelessTraffic(False). 

As a solution we move PauseStatelessTraffic(False) condition. As well as put that within exception block. We will raise an warning and stop those flows when we are getting this type of error.

Code have StartStatelessTrafficBlocking() which will again start all those flows.