### PR TITLE
BGP AS_SEQ Bug fix

### DIFF
--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -343,7 +343,7 @@ class Bgp(Base):
                     ixn_route, "bgpAsPathSegmentList"
                 )
                 ixn_segment["segmentType"] = self.multivalue(
-                    segment.get(type), Bgp._BGP_SEG_TYPE
+                    segment.get("type"), Bgp._BGP_SEG_TYPE
                 )
                 as_numbers = segment.get("as_numbers")
                 ixn_segment["numberOfAsNumberInSegment"] = len(as_numbers)

--- a/tests/bgp/test_bgp_attributes.py
+++ b/tests/bgp/test_bgp_attributes.py
@@ -183,7 +183,7 @@ def validate_community_config(api, community, aspaths, med, origin):
     assert last_two_octets == community.split(":")[1]
 
     as_paths = bgpv4.AsPathASString
-    as_paths = as_paths[0].replace("}", "").replace("{", "")
+    as_paths = as_paths[0].replace(">", "").replace("<", "")
     as_paths = as_paths.split(",")
     as_paths = [int(ele) for ele in as_paths]
     assert as_paths == aspaths
@@ -198,7 +198,7 @@ def validate_community_config(api, community, aspaths, med, origin):
     assert last_two_octets == community.split(":")[1]
 
     as_paths = bgpv6.AsPathASString
-    as_paths = as_paths[0].replace("}", "").replace("{", "")
+    as_paths = as_paths[0].replace(">", "").replace("<", "")
     as_paths = as_paths.split(",")
     as_paths = [int(ele) for ele in as_paths]
     assert as_paths == aspaths


### PR DESCRIPTION
Setting BGP segment.type to 'AS-SEQ' does not work in BGP. 
Issue: https://github.com/sonic-net/sonic-mgmt/issues/23744