### PR TITLE
Dev duration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,10 @@ jobs:
           source ~/.profile
           ${{steps.path.outputs.pythonv}} do.py generate_allure_report
 
+      - name: Ensure allure-report dir exists
+        if: always()
+        run: mkdir -p allure-report
+
       - name: Deploy report to Github Pages
         if: always()
         uses: peaceiris/actions-gh-pages@v4

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -1486,6 +1486,14 @@ class TrafficItem(CustomField):
                 )
         return
 
+    def _validate_integer_field(self, value, field_name):
+        """Raise SnappiIxnException if value is a float (non-integer)."""
+        if isinstance(value, float) and not value.is_integer():
+            raise SnappiIxnException(
+                400,
+                "Application only accepts integer value for %s" % field_name,
+            )
+
     def _configure_duration(self, ce_dict, hl_stream_count, duration):
         """Transform duration flows.duration to
         /traffic/trafficItem[*]/configElement[*]/TransmissionControl"""
@@ -1504,6 +1512,7 @@ class TrafficItem(CustomField):
                 )
                 delay = duration.continuous.get("delay", True)
                 value = delay.get(delay.choice, True)
+                self._validate_integer_field(value, "continuous delay")
                 unit = delay.choice
                 if delay.choice == "microseconds":
                     value = value * 1000
@@ -1521,6 +1530,7 @@ class TrafficItem(CustomField):
                 )
                 delay = duration.fixed_packets.get("delay", True)
                 value = delay.get(delay.choice, True)
+                self._validate_integer_field(value, "fixed_packets delay")
                 unit = delay.choice
                 if delay.choice == "microseconds":
                     value = value * 1000
@@ -1529,11 +1539,7 @@ class TrafficItem(CustomField):
                 ce["transmissionControl"]["startDelayUnits"] = unit
             elif duration.choice == "fixed_seconds":
                 seconds_value = duration.fixed_seconds.get("seconds", True)
-                if not isinstance(seconds_value, int):
-                    raise SnappiIxnException(
-                        400,
-                        "Application only accept integer value for fixed_seconds duration"
-                    )
+                self._validate_integer_field(seconds_value, "fixed_seconds duration")
                 ce["transmissionControl"]["type"] = "fixedDuration"
                 ce["transmissionControl"]["duration"] = seconds_value
                 ce["transmissionControl"]["minGapBytes"] = (
@@ -1541,6 +1547,7 @@ class TrafficItem(CustomField):
                 )
                 delay = duration.fixed_seconds.get("delay", True)
                 value = delay.get(delay.choice, True)
+                self._validate_integer_field(value, "fixed_seconds delay")
                 unit = delay.choice
                 if delay.choice == "microseconds":
                     value = value * 1000
@@ -1559,6 +1566,7 @@ class TrafficItem(CustomField):
                 )
                 inter_burst_gap = duration.burst.get("inter_burst_gap", True)
                 value = inter_burst_gap.get(inter_burst_gap.choice, True)
+                self._validate_integer_field(value, "burst inter_burst_gap")
                 unit = inter_burst_gap.choice
                 if inter_burst_gap.choice == "microseconds":
                     value = value * 1000

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -1566,7 +1566,6 @@ class TrafficItem(CustomField):
                 )
                 inter_burst_gap = duration.burst.get("inter_burst_gap", True)
                 value = inter_burst_gap.get(inter_burst_gap.choice, True)
-                self._validate_integer_field(value, "burst inter_burst_gap")
                 unit = inter_burst_gap.choice
                 if inter_burst_gap.choice == "microseconds":
                     value = value * 1000

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -1528,10 +1528,14 @@ class TrafficItem(CustomField):
                 ce["transmissionControl"]["startDelay"] = value
                 ce["transmissionControl"]["startDelayUnits"] = unit
             elif duration.choice == "fixed_seconds":
+                seconds_value = duration.fixed_seconds.get("seconds", True)
+                if not isinstance(seconds_value, int):
+                    raise SnappiIxnException(
+                        400,
+                        "Application only accept integer value for fixed_seconds duration"
+                    )
                 ce["transmissionControl"]["type"] = "fixedDuration"
-                ce["transmissionControl"]["duration"] = (
-                    duration.fixed_seconds.get("seconds", True)
-                )
+                ce["transmissionControl"]["duration"] = seconds_value
                 ce["transmissionControl"]["minGapBytes"] = (
                     duration.fixed_seconds.get("gap", True)
                 )

--- a/tests/traffic/test_traffic_fixed_seconds_validation.py
+++ b/tests/traffic/test_traffic_fixed_seconds_validation.py
@@ -1,0 +1,24 @@
+import pytest
+from snappi_ixnetwork.exceptions import SnappiIxnException
+
+
+def test_fixed_seconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with fixed_seconds duration where seconds is a float.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because fixed_seconds.seconds only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.fixed_seconds.seconds = 10.5  # Set seconds to a float value
+    try:
+        api.set_config(b2b_raw_config)
+        assert False, "Expected SnappiIxnException was not raised"
+    except SnappiIxnException as err:
+        assert err.status_code == 400
+        assert err.args[0] == 400
+        assert isinstance(err.message, list)
+        assert any(
+            "integer" in msg.lower() for msg in err.message
+        ), "Error message should mention integer requirement"

--- a/tests/traffic/test_traffic_fixed_seconds_validation.py
+++ b/tests/traffic/test_traffic_fixed_seconds_validation.py
@@ -2,6 +2,25 @@ import pytest
 from snappi_ixnetwork.exceptions import SnappiIxnException
 
 
+def _assert_integer_validation_error(api, config):
+    """Helper to assert that set_config raises a 400 SnappiIxnException
+    mentioning integer requirement."""
+    try:
+        api.set_config(config)
+        assert False, "Expected SnappiIxnException was not raised"
+    except SnappiIxnException as err:
+        assert err.status_code == 400
+        assert err.args[0] == 400
+        assert isinstance(err.message, list)
+        assert any(
+            "integer" in msg.lower() for msg in err.message
+        ), "Error message should mention integer requirement"
+
+
+# ---------------------------------------------------------------------------
+# fixed_seconds – seconds field
+# ---------------------------------------------------------------------------
+
 def test_fixed_seconds_float_raises_error(api, b2b_raw_config):
     """
     Configure a flow with fixed_seconds duration where seconds is a float.
@@ -11,14 +30,108 @@ def test_fixed_seconds_float_raises_error(api, b2b_raw_config):
       because fixed_seconds.seconds only accepts integer values.
     """
     flow = b2b_raw_config.flows[0]
-    flow.duration.fixed_seconds.seconds = 10.5  # Set seconds to a float value
-    try:
-        api.set_config(b2b_raw_config)
-        assert False, "Expected SnappiIxnException was not raised"
-    except SnappiIxnException as err:
-        assert err.status_code == 400
-        assert err.args[0] == 400
-        assert isinstance(err.message, list)
-        assert any(
-            "integer" in msg.lower() for msg in err.message
-        ), "Error message should mention integer requirement"
+    flow.duration.fixed_seconds.seconds = 10.5
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+# ---------------------------------------------------------------------------
+# fixed_seconds – delay field
+# ---------------------------------------------------------------------------
+
+def test_fixed_seconds_delay_nanoseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with fixed_seconds duration where delay.nanoseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because fixed_seconds delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.fixed_seconds.seconds = 5
+    flow.duration.fixed_seconds.delay.nanoseconds = 100.7
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+def test_fixed_seconds_delay_microseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with fixed_seconds duration where delay.microseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because fixed_seconds delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.fixed_seconds.seconds = 5
+    flow.duration.fixed_seconds.delay.microseconds = 50.3
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+# ---------------------------------------------------------------------------
+# continuous – delay field
+# ---------------------------------------------------------------------------
+
+def test_continuous_delay_nanoseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with continuous duration where delay.nanoseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because continuous delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.choice = flow.duration.CONTINUOUS
+    flow.duration.continuous.delay.nanoseconds = 200.9
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+def test_continuous_delay_microseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with continuous duration where delay.microseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because continuous delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.choice = flow.duration.CONTINUOUS
+    flow.duration.continuous.delay.microseconds = 75.1
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+# ---------------------------------------------------------------------------
+# fixed_packets – delay field
+# ---------------------------------------------------------------------------
+
+def test_fixed_packets_delay_nanoseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with fixed_packets duration where delay.nanoseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because fixed_packets delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.fixed_packets.packets = 1000
+    flow.duration.fixed_packets.delay.nanoseconds = 300.5
+    _assert_integer_validation_error(api, b2b_raw_config)
+
+
+def test_fixed_packets_delay_microseconds_float_raises_error(api, b2b_raw_config):
+    """
+    Configure a flow with fixed_packets duration where delay.microseconds is
+    a float value.
+
+    Validation:
+    - set_config should raise SnappiIxnException with status_code 400
+      because fixed_packets delay only accepts integer values.
+    """
+    flow = b2b_raw_config.flows[0]
+    flow.duration.fixed_packets.packets = 1000
+    flow.duration.fixed_packets.delay.microseconds = 25.8
+    _assert_integer_validation_error(api, b2b_raw_config)
+


### PR DESCRIPTION
As per OTG model fixed_seconds and seconds in delay can accept float value where as IxNetwork only allows integer values.
Added validation if user gives float value it will throw error stating that it will accept only integer value.
Validation tests corresponding code has been added.