### PR TITLE
Bidirectional traffic and Frame ordering support in flow

### DIFF
--- a/do.py
+++ b/do.py
@@ -11,7 +11,7 @@ from email.mime.text import MIMEText
 
 global ixnexception
 
-SNAPPI_BRANCH=None
+SNAPPI_BRANCH="dev-bidirectional-flow"
 def get_snappi_dev_branch():
     if SNAPPI_BRANCH is not None and SNAPPI_BRANCH != "":
         print(f"Test is using this snappi branch {SNAPPI_BRANCH}")

--- a/do.py
+++ b/do.py
@@ -11,7 +11,7 @@ from email.mime.text import MIMEText
 
 global ixnexception
 
-SNAPPI_BRANCH="dev-bidirectional-flow"
+SNAPPI_BRANCH=None
 def get_snappi_dev_branch():
     if SNAPPI_BRANCH is not None and SNAPPI_BRANCH != "":
         print(f"Test is using this snappi branch {SNAPPI_BRANCH}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = { file = "requirements.txt" }
 
 [project.optional-dependencies]
 testing   = [
-    "snappi==1.58.0",
+    "snappi==1.59.0",
     "pytest",
     "mock",
     "dpkt==1.9.4",

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -722,6 +722,7 @@ class TrafficItem(CustomField):
                     "xpath": tr_xpath,
                     "name": "%s" % flow.name,
                     "srcDestMesh": self._get_mesh_type(flow),
+                    "biDirectional": self._get_bidirectional(flow),
                 }
             )
 
@@ -1336,6 +1337,17 @@ class TrafficItem(CustomField):
                     )
         self.logger.debug("mesh type : %s" % mesh_type)
         return mesh_type
+
+    def _get_bidirectional(self, flow):
+        """Return whether the flow's device endpoints request bidirectional
+        traffic. When enabled, IxNetwork creates traffic sub-flows on both the
+        forward (tx_names -> rx_names) and reverse (rx_names -> tx_names)
+        directions. Only device endpoints support this; port endpoints are
+        always unidirectional.
+        """
+        if flow.tx_rx.choice == "device":
+            return bool(flow.tx_rx.device.bidirectional)
+        return False
 
     def _endpoint_validation(self, flow):
         if flow.tx_rx.choice is None:
@@ -2982,6 +2994,7 @@ class TrafficItem(CustomField):
                     "xpath": tr_xpath,
                     "name": "%s" % flow.name,
                     "srcDestMesh": self._get_mesh_type(flow),
+                    "biDirectional": self._get_bidirectional(flow),
                 }
             )
 

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -1346,7 +1346,10 @@ class TrafficItem(CustomField):
         always unidirectional.
         """
         if flow.tx_rx.choice == "device":
-            return bool(flow.tx_rx.device.bidirectional)
+            bidirectional = flow.tx_rx.device.bidirectional
+            if bidirectional is None:
+                return False
+            return bool(bidirectional)
         return False
 
     def _endpoint_validation(self, flow):

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -1493,6 +1493,7 @@ class TrafficItem(CustomField):
 
             self._configure_options()
             self._configure_latency()
+            self._configure_frame_ordering()
 
     def _fix_srh_encapsulated_fields(self):
         """After importConfig, directly freeze TCP data_offset and UDP length
@@ -1572,6 +1573,48 @@ class TrafficItem(CustomField):
         tracking = [{"xpath": "%s/tracking" % xpath, "trackBy": trackBy}]
         self.logger.debug("tracking : %s" % tracking)
         return {"tracking": tracking}
+    
+    # OTG Port.Options.frame_ordering_mode -> Traffic.FrameOrderingMode
+    _FRAME_ORDERING_MODE = {
+        "no_ordering": "none",
+        "rfc2889": "RFC2889",
+    }
+
+    def _configure_frame_ordering(self):
+        """Apply ``config.options.port_options`` transmit ordering / integrity
+        knobs onto the global traffic options.
+
+        OTG/snappi expresses these through ``Port.Options``:
+          - ``data_integrity``      -> Traffic.Statistics.DataIntegrity
+            (per-frame data integrity signature checking)
+          - ``frame_ordering_mode`` -> Traffic.FrameOrderingMode and
+            Traffic.EnableStreamOrdering (``rfc2889`` enables RFC 2889 stream
+            ordering, ``no_ordering`` transmits frames unordered)
+        """
+        if self.isUhd is True:
+            return
+        options = self._config.get("options")
+        if options is None:
+            return
+        port_options = options.get("port_options")
+        if port_options is None:
+            return
+        traffic = self._api._traffic
+        data_integrity = port_options.get("data_integrity")
+        if data_integrity is not None:
+            ixn_data_integrity = traffic.Statistics.DataIntegrity
+            if ixn_data_integrity.Enabled != data_integrity:
+                ixn_data_integrity.Enabled = data_integrity
+        frame_ordering_mode = port_options.get("frame_ordering_mode")
+        choice = "no_ordering"
+        if frame_ordering_mode is not None and frame_ordering_mode.choice == "rfc2889":
+            choice = "rfc2889"
+        ixn_mode = TrafficItem._FRAME_ORDERING_MODE[choice]
+        enable_ordering = choice == "rfc2889"
+        if traffic.EnableStreamOrdering != enable_ordering:
+            traffic.EnableStreamOrdering = enable_ordering
+        if traffic.FrameOrderingMode != ixn_mode:
+            traffic.FrameOrderingMode = ixn_mode
 
     def _configure_options(self):
         if self.isUhd is True:

--- a/tests/frame_ordering/test_frame_ordering_b2b.py
+++ b/tests/frame_ordering/test_frame_ordering_b2b.py
@@ -1,0 +1,330 @@
+import pytest
+
+
+# NOTE on frame ordering modes
+# ----------------------------
+# The OTG/snappi model expresses transmit ordering through
+# ``Port.Options.frame_ordering_mode`` (no_ordering | rfc2889) which pairs
+# with ``Port.Options.data_integrity``. The snappi build used by this wrapper
+# exposes ``config.options.port_options.data_integrity`` (the sequence /
+# integrity checking knob); the ordering use cases themselves are driven by
+# the surrounding building blocks - flow rate, flow metrics (loss / latency)
+# and the flow end points (port.tx_rx single src->dst, or device.tx_rx with
+# one_to_one / mesh for many-to-many / many-to-one).
+#
+# These b2b tests exercise the use cases from both ordering buckets:
+#   rfc2544 (no_ordering) : line-rate throughput, loss/latency, single src->dst
+#   rfc2889               : fully-meshed forwarding, many-to-one congestion/HOL,
+#                           broadcast forwarding
+#
+# All tests run back-to-back over the two ports from settings and never create
+# more than 6 device end points.
+
+
+def _add_ip_devices(cfg, utils, tx_count, rx_count):
+    """Create ``tx_count`` ipv4 devices on the tx port and ``rx_count`` on the
+    rx port (back-to-back). Total end points must stay within 6.
+    Returns (tx_ip_names, rx_ip_names) - the ipv4 address names used as flow
+    end points.
+    """
+    assert tx_count + rx_count <= 6
+    count = max(tx_count, rx_count)
+    mac_tx = utils.mac_or_ip_addr_from_counter_pattern(
+        "00:10:10:20:20:10", "00:00:00:00:00:01", count, True
+    )
+    mac_rx = utils.mac_or_ip_addr_from_counter_pattern(
+        "00:10:10:20:20:20", "00:00:00:00:00:01", count, False
+    )
+    ip_tx = utils.mac_or_ip_addr_from_counter_pattern(
+        "10.1.1.1", "0.0.1.0", count, True, False
+    )
+    ip_rx = utils.mac_or_ip_addr_from_counter_pattern(
+        "10.1.1.2", "0.0.1.0", count, True, False
+    )
+
+    tx_names, rx_names = [], []
+    for i in range(tx_count):
+        dev = cfg.devices.device(name="tx_dev_%d" % (i + 1))[-1]
+        eth = dev.ethernets.add()
+        eth.name = "tx_eth_%d" % (i + 1)
+        eth.connection.port_name = cfg.ports[0].name
+        eth.mac = mac_tx[i]
+        ip = eth.ipv4_addresses.add()
+        ip.name = "tx_ipv4_%d" % (i + 1)
+        ip.address = ip_tx[i]
+        ip.gateway = ip_rx[i]
+        ip.prefix = 24
+        tx_names.append(ip.name)
+
+    for i in range(rx_count):
+        dev = cfg.devices.device(name="rx_dev_%d" % (i + 1))[-1]
+        eth = dev.ethernets.add()
+        eth.name = "rx_eth_%d" % (i + 1)
+        eth.connection.port_name = cfg.ports[1].name
+        eth.mac = mac_rx[i]
+        ip = eth.ipv4_addresses.add()
+        ip.name = "rx_ipv4_%d" % (i + 1)
+        ip.address = ip_rx[i]
+        ip.gateway = ip_tx[i]
+        ip.prefix = 24
+        rx_names.append(ip.name)
+
+    return tx_names, rx_names
+
+
+def _frames_ok(api, utils, packets):
+    port_results, flow_results = utils.get_all_stats(api)
+    return utils.total_frames_ok(port_results, flow_results, packets)
+
+
+# ----------------------------------------------------------------------------
+# rfc2544 use cases  (frame_ordering_mode = no_ordering)
+# ----------------------------------------------------------------------------
+
+@pytest.mark.skip("WIP: frame ordering b2b coverage")
+@pytest.mark.e2e
+def test_rfc2544_throughput(api, b2b_raw_config, utils):
+    """rfc2544 UC#1 - throughput / line-rate saturation.
+
+    Single src->dst flow at 100% line rate; ordering is irrelevant, only that
+    the DUT forwards at rate with zero loss. data_integrity stays off (lowest
+    scheduler overhead, the natural no_ordering setting).
+    Validation: tx == rx frames (zero loss) at line rate.
+    """
+    SIZE = 512
+    PACKETS = 100000
+
+    b2b_raw_config.options.port_options.data_integrity = False
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.NO_ORDERING
+    )
+
+    f = b2b_raw_config.flows[0]
+    f.size.fixed = SIZE
+    f.rate.percentage = 100
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "line-rate throughput with zero loss",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+    _, flow_results = utils.get_all_stats(api)
+    for f in flow_results:
+        assert f.frames_tx == f.frames_rx == PACKETS
+
+@pytest.mark.skip("WIP: frame ordering b2b coverage")
+@pytest.mark.e2e
+def test_rfc2544_loss_latency(api, b2b_raw_config, utils):
+    """rfc2544 UC#2 - loss / latency measurement.
+
+    Single flow with loss and store-forward latency metrics enabled; sequence
+    numbers are not inspected so no_ordering is the right setting.
+    Validation: loss is reported and latency min/avg/max are present.
+    """
+    SIZE = 1024
+    PACKETS = 10000
+
+    b2b_raw_config.options.port_options.data_integrity = False
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.NO_ORDERING
+    )
+
+    f = b2b_raw_config.flows[0]
+    f.size.fixed = SIZE
+    f.rate.percentage = 50
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+    f.metrics.timestamps = True
+    f.metrics.latency.enable = True
+    f.metrics.latency.mode = f.metrics.latency.STORE_FORWARD
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "loss/latency stats to be as expected",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+    _, flow_results = utils.get_all_stats(api)
+    for f in flow_results:
+        assert f.loss is not None
+        latency = getattr(f, "latency")
+        assert getattr(latency, "minimum_ns") is not None
+        assert getattr(latency, "average_ns") is not None
+        assert getattr(latency, "maximum_ns") is not None
+
+
+@pytest.mark.e2e
+def test_rfc2544_single_src_dst(api, b2b_raw_config, utils):
+    """rfc2544 UC#3 - single-flow, single src->dst.
+
+    With one flow on the port there is nothing to interleave, so ordering is
+    moot and no_ordering avoids needless scheduler overhead.
+    Validation: tx == rx frames and bytes.
+    """
+    SIZE = 256
+    PACKETS = 50000
+
+    b2b_raw_config.options.port_options.data_integrity = False
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.NO_ORDERING
+    )
+
+    f = b2b_raw_config.flows[0]
+    f.packet.ethernet().ipv4()
+    f.size.fixed = SIZE
+    f.rate.percentage = 30
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "single src->dst stats to be as expected",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+    port_results, flow_results = utils.get_all_stats(api)
+    assert utils.total_bytes_ok(port_results, flow_results, PACKETS * SIZE)
+
+
+# ----------------------------------------------------------------------------
+# rfc2889 use cases
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_rfc2889_fully_meshed_forwarding(api, b2b_raw_config, utils):
+    """rfc2889 UC#1 - fully-meshed forwarding (many-to-many).
+
+    3 tx devices send to 3 rx devices in mesh mode (6 end points). RFC 2889
+    ordering keeps the per-stream sequencing valid under the mesh, so
+    data_integrity (sequence checking) is enabled.
+    Validation: every mesh combination is forwarded (tx == rx frames).
+    """
+    SIZE = 512
+    PACKETS = 30000
+    TX, RX = 3, 3
+
+    b2b_raw_config.options.port_options.data_integrity = True
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.RFC2889
+    )
+
+    tx_names, rx_names = _add_ip_devices(b2b_raw_config, utils, TX, RX)
+
+    b2b_raw_config.flows.clear()
+    f = b2b_raw_config.flows.flow(name="mesh")[-1]
+    f.tx_rx.device.tx_names = tx_names
+    f.tx_rx.device.rx_names = rx_names
+    f.tx_rx.device.mode = f.tx_rx.device.MESH
+    f.size.fixed = SIZE
+    f.rate.percentage = 20
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "fully-meshed forwarding stats to be as expected",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+@pytest.mark.skip("WIP: frame ordering b2b coverage")
+@pytest.mark.e2e
+def test_rfc2889_congestion_hol_many_to_one(api, b2b_raw_config, utils):
+    """rfc2889 UC#3 - congestion control / Head-of-Line blocking.
+
+    Many-to-one oversubscription: 5 tx devices blast a single rx device
+    (6 end points). Stream ordering lets the receiver attribute frames per
+    source stream, so data_integrity is enabled.
+    Validation: frames forwarded to the single destination (tx == rx frames).
+    """
+    SIZE = 512
+    PACKETS = 30000
+    TX, RX = 5, 1
+
+    b2b_raw_config.options.port_options.data_integrity = True
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.RFC2889
+    )
+
+    tx_names, rx_names = _add_ip_devices(b2b_raw_config, utils, TX, RX)
+
+    b2b_raw_config.flows.clear()
+    f = b2b_raw_config.flows.flow(name="many_to_one")[-1]
+    f.tx_rx.device.tx_names = tx_names
+    f.tx_rx.device.rx_names = rx_names
+    f.tx_rx.device.mode = f.tx_rx.device.MESH
+    f.size.fixed = SIZE
+    f.rate.percentage = 20
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "many-to-one congestion stats to be as expected",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+@pytest.mark.skip("WIP: frame ordering b2b coverage")
+@pytest.mark.e2e
+def test_rfc2889_broadcast_forwarding(api, b2b_raw_config, utils):
+    """rfc2889 UC#4 - broadcast forwarding & latency.
+
+    One src -> broadcast destination MAC; RFC 2889 ordering keeps the
+    broadcast stream measurable. Latency is enabled to cover broadcast
+    latency, and data_integrity is on for sequence checking.
+    Validation: frames forwarded and latency metrics present.
+    """
+    SIZE = 256
+    PACKETS = 20000
+
+    b2b_raw_config.options.port_options.data_integrity = True
+    b2b_raw_config.options.port_options.frame_ordering_mode.choice = (
+        b2b_raw_config.options.port_options.frame_ordering_mode.RFC2889
+    )
+
+    f = b2b_raw_config.flows[0]
+    eth = f.packet.ethernet()[-1]
+    eth.dst.value = "ff:ff:ff:ff:ff:ff"
+    eth.src.value = "00:10:10:20:20:10"
+    f.size.fixed = SIZE
+    f.rate.percentage = 20
+    f.duration.fixed_packets.packets = PACKETS
+    f.metrics.enable = True
+    f.metrics.loss = True
+    f.metrics.latency.enable = True
+    f.metrics.latency.mode = f.metrics.latency.STORE_FORWARD
+
+    utils.start_traffic(api, b2b_raw_config, start_capture=False)
+    utils.wait_for(
+        lambda: _frames_ok(api, utils, PACKETS),
+        "broadcast forwarding stats to be as expected",
+        timeout_seconds=30,
+    )
+    utils.stop_traffic(api, b2b_raw_config)
+
+    _, flow_results = utils.get_all_stats(api)
+    for f in flow_results:
+        latency = getattr(f, "latency")
+        assert getattr(latency, "average_ns") is not None
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])

--- a/tests/traffic/test_traffic_bidirectional.py
+++ b/tests/traffic/test_traffic_bidirectional.py
@@ -1,0 +1,100 @@
+import pytest
+
+
+def test_traffic_bidirectional(api, b2b_raw_config):
+    """
+    Configure IPv4 devices on the Tx and Rx ports and create a flow with
+    device endpoints using the bidirectional option under flows->tx_rx->device.
+
+    When bidirectional is enabled, IxNetwork creates traffic sub-flows in both
+    the forward (tx_names -> rx_names) and reverse (rx_names -> tx_names)
+    directions.
+
+    Validation:
+    - the imported IxNetwork traffic item has BiDirectional set to True.
+    """
+    b2b_raw_config.flows.clear()
+    config = b2b_raw_config
+    d1, d2 = config.devices.device(name="d1").device(name="d2")
+
+    eth1 = d1.ethernets.add()
+    eth1.name = "eth1"
+    eth1.connection.port_name = config.ports[0].name
+    eth1.mac = "00:ad:aa:13:11:01"
+
+    eth2 = d2.ethernets.add()
+    eth2.name = "eth2"
+    eth2.connection.port_name = config.ports[1].name
+    eth2.mac = "00:ad:aa:13:11:02"
+
+    ip1 = eth1.ipv4_addresses.add()
+    ip1.name = "ipv41"
+    ip1.address = "10.1.1.1"
+    ip1.gateway = "10.1.1.2"
+
+    ip2 = eth2.ipv4_addresses.add()
+    ip2.name = "ipv42"
+    ip2.address = "10.1.1.2"
+    ip2.gateway = "10.1.1.1"
+
+    f1 = config.flows.flow(name="f1")[-1]
+    f1.tx_rx.device.tx_names = [ip1.name]
+    f1.tx_rx.device.rx_names = [ip2.name]
+    f1.tx_rx.device.bidirectional = True
+    f1.packet.ethernet().ipv4().tcp()
+
+    api.set_config(config)
+
+    validate_bidirectional(api, "f1", True)
+
+
+def test_traffic_bidirectional_disabled(api, b2b_raw_config):
+    """
+    By default device flows are unidirectional. Verify that when bidirectional
+    is not set the imported IxNetwork traffic item has BiDirectional False.
+    """
+    b2b_raw_config.flows.clear()
+    config = b2b_raw_config
+    d1, d2 = config.devices.device(name="d1").device(name="d2")
+
+    eth1 = d1.ethernets.add()
+    eth1.name = "eth1"
+    eth1.connection.port_name = config.ports[0].name
+    eth1.mac = "00:ad:aa:13:11:01"
+
+    eth2 = d2.ethernets.add()
+    eth2.name = "eth2"
+    eth2.connection.port_name = config.ports[1].name
+    eth2.mac = "00:ad:aa:13:11:02"
+
+    ip1 = eth1.ipv4_addresses.add()
+    ip1.name = "ipv41"
+    ip1.address = "10.1.1.1"
+    ip1.gateway = "10.1.1.2"
+
+    ip2 = eth2.ipv4_addresses.add()
+    ip2.name = "ipv42"
+    ip2.address = "10.1.1.2"
+    ip2.gateway = "10.1.1.1"
+
+    f1 = config.flows.flow(name="f1")[-1]
+    f1.tx_rx.device.tx_names = [ip1.name]
+    f1.tx_rx.device.rx_names = [ip2.name]
+    f1.packet.ethernet().ipv4().tcp()
+
+    api.set_config(config)
+
+    validate_bidirectional(api, "f1", False)
+
+
+def validate_bidirectional(api, flow_name, expected):
+    """
+    Validate that the imported IxNetwork traffic item carries the expected
+    BiDirectional value.
+    """
+    traffic_item = api._ixnetwork.Traffic.TrafficItem.find(Name=flow_name)
+    assert traffic_item.BiDirectional == expected
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])

--- a/tests/traffic/test_traffic_bidirectional.py
+++ b/tests/traffic/test_traffic_bidirectional.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_traffic_bidirectional(api, b2b_raw_config):
+def test_traffic_bidirectional(api, b2b_raw_config, utils):
     """
     Configure IPv4 devices on the Tx and Rx ports and create a flow with
     device endpoints using the bidirectional option under flows->tx_rx->device.
@@ -12,7 +12,17 @@ def test_traffic_bidirectional(api, b2b_raw_config):
 
     Validation:
     - the imported IxNetwork traffic item has BiDirectional set to True.
+    - traffic starts and every configured packet is received without loss.
+      Since the flow is bidirectional, both directions transmit, so the total
+      transmitted/received count is 2 * packets.
     """
+    packets = 1000
+    size = 128
+
+    # enable per-sub-flow (Tx Port / Rx Port) metric rows so the forward and
+    # reverse directions of the bidirectional flow are reported separately.
+    api._enable_flow_tracking(True)
+
     b2b_raw_config.flows.clear()
     config = b2b_raw_config
     d1, d2 = config.devices.device(name="d1").device(name="d2")
@@ -42,10 +52,33 @@ def test_traffic_bidirectional(api, b2b_raw_config):
     f1.tx_rx.device.rx_names = [ip2.name]
     f1.tx_rx.device.bidirectional = True
     f1.packet.ethernet().ipv4().tcp()
+    f1.size.fixed = size
+    f1.rate.percentage = 10
+    f1.duration.fixed_packets.packets = packets
+    f1.metrics.enable = True
+    f1.metrics.loss = True
 
     api.set_config(config)
 
     validate_bidirectional(api, "f1", True)
+
+    utils.start_traffic(api, config, start_capture=False)
+
+    # frameCount is split across the forward + reverse sub-flows, so the
+    # combined tx/rx across all sub-flows equals the configured packet count.
+    expected = packets
+    utils.wait_for(
+        lambda: results_ok(api, ["f1"], expected),
+        "stats to be as expected",
+        timeout_seconds=30,
+    )
+
+    # with flow tracking enabled we expect two sub-flow rows: the forward
+    # (port0 -> port1) and reverse (port1 -> port0) directions.
+    sub_flows = print_flow_metrics(api, ["f1"])
+    assert len(sub_flows) == 2
+
+    utils.stop_traffic(api, config)
 
 
 def test_traffic_bidirectional_disabled(api, b2b_raw_config):
@@ -94,6 +127,45 @@ def validate_bidirectional(api, flow_name, expected):
     """
     traffic_item = api._ixnetwork.Traffic.TrafficItem.find(Name=flow_name)
     assert traffic_item.BiDirectional == expected
+
+
+def results_ok(api, flow_names, expected):
+    """
+    Returns True if the received frame count matches the expected count with
+    no traffic loss, else False.
+    """
+    request = api.metrics_request()
+    request.flow.flow_names = flow_names
+    flow_results = api.get_metrics(request).flow_metrics
+    frames_tx = sum([f.frames_tx for f in flow_results])
+    frames_rx = sum([f.frames_rx for f in flow_results])
+    return frames_tx == expected and frames_rx == expected
+
+
+def print_flow_metrics(api, flow_names):
+    """
+    Fetch flow metrics for the given flows and print each sub-flow's stats,
+    differentiated by its Tx Port / Rx Port. With flow tracking enabled a
+    bidirectional flow yields one row per direction. Returns the sub-flow rows.
+    """
+    request = api.metrics_request()
+    request.flow.flow_names = flow_names
+    flow_results = api.get_metrics(request).flow_metrics
+    print("\nFlow metrics:")
+    print(flow_results)
+    for flow in flow_results:
+        print(
+            "  %s [%s -> %s]: tx=%s rx=%s loss=%s"
+            % (
+                flow.name,
+                flow.port_tx,
+                flow.port_rx,
+                flow.frames_tx,
+                flow.frames_rx,
+                flow.loss,
+            )
+        )
+    return flow_results
 
 
 if __name__ == "__main__":

--- a/tests/traffic/test_traffic_bidirectional.py
+++ b/tests/traffic/test_traffic_bidirectional.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 def test_traffic_bidirectional(api, b2b_raw_config, utils):
     """
     Configure IPv4 devices on the Tx and Rx ports and create a flow with
@@ -25,6 +24,12 @@ def test_traffic_bidirectional(api, b2b_raw_config, utils):
 
     b2b_raw_config.flows.clear()
     config = b2b_raw_config
+
+    config.options.port_options.frame_ordering_mode.choice = (
+        config.options.port_options.frame_ordering_mode.RFC2889
+    )
+    # config.options.port_options.data_integrity = True
+
     d1, d2 = config.devices.device(name="d1").device(name="d2")
 
     eth1 = d1.ethernets.add()
@@ -114,6 +119,7 @@ def test_traffic_bidirectional_disabled(api, b2b_raw_config):
     f1.tx_rx.device.tx_names = [ip1.name]
     f1.tx_rx.device.rx_names = [ip2.name]
     f1.packet.ethernet().ipv4().tcp()
+    f1.metrics.enable = True
 
     api.set_config(config)
 

--- a/tests/traffic/test_traffic_json.py
+++ b/tests/traffic/test_traffic_json.py
@@ -11,6 +11,7 @@ expected_raw_type = {
             "xpath": "/traffic/trafficItem[1]",
             "name": "f1",
             "srcDestMesh": "oneToOne",
+            "biDirectional": False,
             "endpointSet": [
                 {
                     "xpath": "/traffic/trafficItem[1]/endpointSet[1]",
@@ -307,6 +308,7 @@ expected_device_type = {
             "xpath": "/traffic/trafficItem[1]",
             "name": "f1",
             "srcDestMesh": "manyToMany",
+            "biDirectional": False,
             "trafficType": "ipv4",
             "endpointSet": [
                 {

--- a/tests/uhd/test_uhd_mock.py
+++ b/tests/uhd/test_uhd_mock.py
@@ -28,6 +28,7 @@ expected_global = {
             "xpath": "/traffic/trafficItem[1]",
             "name": "f1",
             "srcDestMesh": "oneToOne",
+            "biDirectional": False,
             "endpointSet": [
                 {
                     "xpath": "/traffic/trafficItem[1]/endpointSet[1]",


### PR DESCRIPTION
Added bidirectional support in flow, if this is enabled  in traffic item, creates traffic sub-flows on both the forward (tx_names->rx_names) and reverse (rx_names->tx_names) directions.

Added Frame ordering Feature.
Options->per_port_options-> frame_ordering (choices: no_ordering (default behaviour) and RFC2889)

Test Case:
1. Enable bidirectional flow and validate it in traffic item whether it is enabled or not.
2. Validate default value as false in Traffic item if it's not given.
3. Added Full mesh test using bi-directional traffic and RFC2889