### PR TITLE
BGP Dual stack

### DIFF
--- a/snappi_ixnetwork/device/compactor.py
+++ b/snappi_ixnetwork/device/compactor.py
@@ -85,7 +85,12 @@ class Compactor(object):
             if key == "name":
                 parent[key] = self._get_names(parent)
                 self._api.ixn_objects.set_scalable(parent)
-                self._api.ixn_routes.set_scalable(parent)
+                # ixn_routes entries must be updated even when the key sets
+                # of the pre-compaction member node and the representative
+                # differ (data-dependent IPv6 divergence).  The compactor
+                # walks top-down so the last write is always the route
+                # property node — the correct one.
+                self._api.ixn_routes.set_scalable(parent, strict_key_match=False)
                 continue
             if isinstance(value, list):
                 for val in value:

--- a/snappi_ixnetwork/device/ngpf.py
+++ b/snappi_ixnetwork/device/ngpf.py
@@ -317,7 +317,7 @@ class Ngpf(Base):
                     )
                 )
             else:
-                ixn_obj_idx_list[route_info].extend(
+                ixn_obj_idx_list[ixn_obj].extend(
                     list(
                         range(
                             route_info.index,

--- a/snappi_ixnetwork/objectdb.py
+++ b/snappi_ixnetwork/objectdb.py
@@ -48,7 +48,7 @@ class IxNetObjects(object):
             ixnobject, self._api.ngpf.working_dg
         )
 
-    def set_scalable(self, ixnobject):
+    def set_scalable(self, ixnobject, strict_key_match=True):
         names = ixnobject.get("name")
         self.logger.debug("set_scalable names : %s" % names)
         set_names = []
@@ -57,11 +57,20 @@ class IxNetObjects(object):
                 continue
             if name not in self._ixnet_infos:
                 continue
-            # Same name may present within different object structure
-            old_keys = sorted(self._ixnet_infos[name].ixnobject)
-            keys = sorted(ixnobject)
-            if old_keys != keys:
-                continue
+            # Same name may present within different object structure.
+            # When strict_key_match=True (default, used by ixn_objects) the
+            # original guard is kept: skip if the key sets differ so that a
+            # cross-type clobber (e.g. bgpV6IPRouteProperty overwriting the
+            # ipv6PrefixPools entry) is prevented.
+            # When strict_key_match=False (used by ixn_routes) the key-match
+            # guard is bypassed entirely; the compactor walks top-down so the
+            # last write for a given name is always the deepest (route
+            # property) node, which is the correct one.
+            if strict_key_match:
+                old_keys = sorted(self._ixnet_infos[name].ixnobject)
+                keys = sorted(ixnobject)
+                if old_keys != keys:
+                    continue
             set_names.append(name)
             self._ixnet_infos[name] = IxNetInfo(
                 ixnobject,

--- a/tests/bgp/test_ipv6_route_compaction.py
+++ b/tests/bgp/test_ipv6_route_compaction.py
@@ -1,0 +1,279 @@
+"""
+Hardware-free regression tests for two defects in BGP subset-withdraw
+when a device-group or network-group multiplier > 1 is used.
+
+Defect A (ngpf.py)   — set_route_state indexes the accumulator dict by the
+                        wrong key when >=2 names share a compacted IxN node,
+                        always raising KeyError on list (subset) withdraw.
+Defect B (objectdb.py) — set_scalable silently skips IPv6 members whose
+                          pre-compaction key-set differs from the compacted
+                          representative, leaving them with xpath=='' and
+                          index==0.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from snappi_ixnetwork.objectdb import IxNetObjects, IxNetInfo
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_info(xpath="", index=0, multiplier=1, names=None, extra_keys=None):
+    """Return an IxNetInfo backed by a minimal dict ixnobject."""
+    ixnobj = {"xpath": xpath}
+    if extra_keys:
+        ixnobj.update(extra_keys)
+    return IxNetInfo(
+        ixnobj,
+        working_dg=MagicMock(),
+        index=index,
+        multiplier=multiplier,
+        names=names or [],
+    )
+
+
+def _make_ngpf(route_infos):
+    """
+    Return a minimal Ngpf instance that can execute set_route_state without
+    touching IxNetwork hardware.
+
+    route_infos: dict of {route_name: IxNetInfo}
+    """
+    from snappi_ixnetwork.device.ngpf import Ngpf
+
+    api = MagicMock()
+    api.ixn_routes.get.side_effect = lambda name: route_infos[name]
+    api.ixn_routes.names = list(route_infos.keys())
+
+    ngpf = Ngpf.__new__(Ngpf)
+    ngpf.api = api
+    ngpf.logger = MagicMock()
+
+    def _select_props(xpath, properties=None):
+        # Build a values list large enough to cover all indices for this xpath.
+        max_end = max(
+            info.index + info.multiplier
+            for info in route_infos.values()
+            if info.xpath == xpath
+        )
+        return {"active": {"values": [True] * max_end}}
+
+    ngpf.select_properties = MagicMock(side_effect=_select_props)
+    ngpf.configure_value = MagicMock(return_value={"xpath": "/mock"})
+    ngpf.imports = MagicMock()
+
+    return ngpf
+
+
+def _make_db():
+    """Return an IxNetObjects with a mocked API."""
+    api = MagicMock()
+    api.ngpf.working_dg = MagicMock()
+    db = IxNetObjects.__new__(IxNetObjects)
+    db._api = api
+    db._ixnet_infos = {}
+    db.logger = MagicMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Fix A — set_route_state
+# ---------------------------------------------------------------------------
+
+def test_set_route_state_subset_does_not_raise_keyerror():
+    """
+    Two names that resolve to the same compacted IxN node must not raise
+    KeyError when passed together as a list.  This is the direct customer
+    symptom: individual withdraw works, subset (list) withdraw fails.
+    """
+    shared_xpath = "/topo[1]/dg[1]/ng[1]/bgpV6IPRouteProperty[1]"
+    route_infos = {
+        "peer0_routes_ipv6": _make_info(xpath=shared_xpath, index=0),
+        "peer1_routes_ipv6": _make_info(xpath=shared_xpath, index=1),
+    }
+    ngpf = _make_ngpf(route_infos)
+
+    payload = MagicMock()
+    payload.state = "withdraw"
+    payload.names = ["peer0_routes_ipv6", "peer1_routes_ipv6"]
+
+    # Must not raise KeyError
+    result = ngpf.set_route_state(payload)
+    assert result is not None
+
+    # One compacted node → configure_value called exactly once
+    assert ngpf.configure_value.call_count == 1
+    # Both instance indices must be set to False (withdrawn)
+    values = ngpf.configure_value.call_args[0][2]
+    assert values[0] is False
+    assert values[1] is False
+
+
+def test_set_route_state_single_name_still_works():
+    """Single-name withdrawal must be unaffected by the fix."""
+    xpath = "/topo[1]/dg[1]/ng[1]/bgpV4IPRouteProperty[1]"
+    route_infos = {
+        "peer0_routes_ipv4": _make_info(xpath=xpath, index=0),
+    }
+    ngpf = _make_ngpf(route_infos)
+
+    payload = MagicMock()
+    payload.state = "withdraw"
+    payload.names = ["peer0_routes_ipv4"]
+
+    result = ngpf.set_route_state(payload)
+    assert result is not None
+
+    assert ngpf.configure_value.call_count == 1
+    values = ngpf.configure_value.call_args[0][2]
+    assert values[0] is False
+
+
+def test_set_route_state_full_list_withdraws_all_instances():
+    """
+    All three names on the same compacted node: every instance must be
+    withdrawn when the full list is supplied.
+    """
+    xpath = "/topo[1]/dg[1]/ng[1]/bgpV6IPRouteProperty[1]"
+    route_infos = {
+        "peer0_routes_ipv6": _make_info(xpath=xpath, index=0),
+        "peer1_routes_ipv6": _make_info(xpath=xpath, index=1),
+        "peer2_routes_ipv6": _make_info(xpath=xpath, index=2),
+    }
+    ngpf = _make_ngpf(route_infos)
+
+    payload = MagicMock()
+    payload.state = "withdraw"
+    payload.names = list(route_infos.keys())
+
+    ngpf.set_route_state(payload)
+
+    # Single node → one configure_value call; all three values False
+    assert ngpf.configure_value.call_count == 1
+    values = ngpf.configure_value.call_args[0][2]
+    assert values[0] is False
+    assert values[1] is False
+    assert values[2] is False
+
+
+# ---------------------------------------------------------------------------
+# Fix B — set_scalable  (currently FAILING until Fix B is applied)
+# ---------------------------------------------------------------------------
+
+def _seed_db_with_members(db, names, stale_obj_factory):
+    """Pre-register each name in db with an object returned by the factory."""
+    for name in names:
+        db._ixnet_infos[name] = IxNetInfo(
+            stale_obj_factory(name),
+            working_dg=MagicMock(),
+            index=0,
+            multiplier=1,
+        )
+
+
+def test_set_scalable_ipv6_members_inherit_representative_xpath():
+    """
+    After set_scalable with strict_key_match=False (as used by ixn_routes),
+    every member name must point to the representative ixnobject and carry a
+    unique index in [0, N) even when the pre-compaction member's key set
+    differs from the compacted representative (IPv6 data-dependent divergence).
+    """
+    N = 4
+    names = ["peer%d_routes_ipv6" % i for i in range(N)]
+
+    # Simulate IPv6 pre-compaction nodes: each has an extra key absent from
+    # the representative (this is what makes old_keys != keys trip).
+    def stale_factory(name):
+        return {
+            "xpath": "",
+            "name": name,
+            "networkAddress": "4000::1",
+            "prefixLength": 128,
+            "ipv6ExtendedCommunities": [],  # extra key absent on representative
+        }
+
+    db = _make_db()
+    _seed_db_with_members(db, names, stale_factory)
+
+    # Compacted representative: same base keys as before, minus the extra one
+    representative = {
+        "xpath": "/topo[1]/dg[1]/ng[1]/ipv6PrefixPools[1]/bgpV6IPRouteProperty[1]",
+        "name": names,
+        "networkAddress": "4000::1",
+        "prefixLength": 128,
+    }
+    db.set_scalable(representative, strict_key_match=False)
+
+    indices = []
+    for name in names:
+        info = db._ixnet_infos[name]
+        assert info.ixnobject is representative, (
+            "%s still points to its stale pre-compaction object" % name
+        )
+        indices.append(info.index)
+
+    assert sorted(indices) == list(range(N)), (
+        "Expected unique indices 0..%d, got %s" % (N - 1, indices)
+    )
+
+
+def test_set_scalable_no_regression_for_identical_keysets():
+    """
+    IPv4-style members whose pre-compaction key-set matches the compacted
+    representative are still registered correctly under the default
+    strict_key_match=True mode.
+    """
+    N = 3
+    names = ["peer%d_routes_ipv4" % i for i in range(N)]
+
+    def stale_factory(name):
+        return {
+            "xpath": "",
+            "name": name,
+            "networkAddress": "10.0.0.1",
+            "prefixLength": 32,
+        }
+
+    db = _make_db()
+    _seed_db_with_members(db, names, stale_factory)
+
+    representative = {
+        "xpath": "/topo[1]/dg[1]/ng[1]/ipv4PrefixPools[1]/bgpIPRouteProperty[1]",
+        "name": names,
+        "networkAddress": "10.0.0.1",
+        "prefixLength": 32,
+    }
+    db.set_scalable(representative)
+
+    indices = [db._ixnet_infos[n].index for n in names]
+    assert sorted(indices) == list(range(N))
+
+
+def test_set_scalable_preserves_foreign_object_with_usable_xpath():
+    """
+    With the default strict_key_match=True (used by ixn_objects), a
+    same-named entry whose key set differs from the incoming node must NOT
+    be overwritten.  This prevents cross-type clobbers such as a
+    bgpV6IPRouteProperty node overwriting an ipv6PrefixPools entry.
+    """
+    db = _make_db()
+    # A legitimate entry with a real (non-empty) xpath and distinct keys
+    foreign_obj = {"xpath": "/real/other/xpath[1]", "name": "shared", "differentKey": True}
+    db._ixnet_infos["shared"] = IxNetInfo(
+        foreign_obj, working_dg=MagicMock(), index=5, multiplier=1
+    )
+
+    # An incoming representative with a different key-set
+    representative = {
+        "xpath": "",
+        "name": ["shared"],
+        "networkAddress": "10.0.0.1",
+    }
+    db.set_scalable(representative)
+
+    info = db._ixnet_infos["shared"]
+    assert info.xpath == "/real/other/xpath[1]", "Foreign entry must not be clobbered"
+    assert info.index == 5

--- a/tests/bgp/test_ipv6_route_withdraw.py
+++ b/tests/bgp/test_ipv6_route_withdraw.py
@@ -1,0 +1,198 @@
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# BGP IPv6 route-range withdraw — compacted node / multiplier scenario
+#
+# When N structurally-identical IPv6 BGP route ranges are configured (one per
+# device-group instance, multiplier > 1), the compactor merges them into a
+# single multiplied IxNetwork node.  Two defects existed in that path:
+#
+#   Defect A (ngpf.py)    — set_route_state raised KeyError when >= 2 names
+#                           that share the same compacted node were passed as a
+#                           list.  A single name never hit the else-branch, so
+#                           individual withdraw worked; subset (list) withdraw
+#                           did not.
+#
+#   Defect B (objectdb.py) — set_scalable silently skipped IPv6 members whose
+#                            pre-compaction key set differed from the compacted
+#                            representative, leaving them with xpath == '' and
+#                            index == 0.  This made any per-name operation on
+#                            those members fail or target the wrong instance.
+#
+# This test is the end-to-end gate for both defects:
+#   * N = 4 identical eBGP peers (>= 2 is enough to force compaction).
+#   * Each peer advertises one IPv6 route range; all ranges compact into one
+#     multiplied bgpV6IPRouteProperty node with N instances.
+#   * A subset (list of >= 2 names) is withdrawn, then re-advertised.
+# --------------------------------------------------------------------------- #
+
+PEER_COUNT = 4          # >= 2 is enough to force compaction
+ROUTE_COUNT = 5         # /128 prefixes advertised per peer
+
+
+def _v6_route_names(prefix="tc1"):
+    return ["%s_peer%d_routes_ipv6" % (prefix, i) for i in range(PEER_COUNT)]
+
+
+def test_ipv6_route_withdraw_subset_e2e(api, b2b_raw_config, utils):
+    """Verify that a subset of IPv6 route ranges that were compacted into a
+    single multiplied node can be withdrawn and re-advertised by name.
+
+    Scenario
+    --------
+    N identical eBGP peers are configured, each advertising one IPv6 route
+    range.  Because all ranges are structurally identical, snappi_ixnetwork
+    compacts them into a single bgpV6IPRouteProperty node with N instances.
+
+    The test asserts:
+      1. Pre-condition: every compacted member resolves to a non-empty xpath
+         and a unique index in [0, N) (Defect B regression check).
+      2. Withdrawing a subset by list of names does not raise an error
+         (Defect A regression check).
+      3. Only the requested instances flip inactive; untouched members remain
+         advertised.
+      4. Re-advertising the same subset restores all instances.
+    """
+    config = b2b_raw_config
+    api.set_config(api.config())
+    config.flows.clear()
+
+    p1, p2 = config.ports
+    route_names = _v6_route_names()
+
+    # N identical tx peers on p1, mirrored by N rx peers on p2. Each peer sits
+    # on its own /64 so the eBGP sessions come up back-to-back; the ranges are
+    # structurally identical, so snappi_ixnetwork compacts them into one node.
+    for i in range(PEER_COUNT):
+        # --- tx side ---
+        tx_dev = config.devices.add(name="tx_peer%d" % i)
+        tx_eth = tx_dev.ethernets.add(name="tx_eth%d" % i)
+        tx_eth.connection.port_name = p1.name
+        tx_eth.mac = "00:10:00:00:00:%02x" % i
+        tx_ip = tx_eth.ipv6_addresses.add(name="tx_ip%d" % i)
+        tx_ip.address = "2000:%d::1" % i
+        tx_ip.gateway = "2000:%d::2" % i
+        tx_ip.prefix = 64
+
+        tx_bgp = tx_dev.bgp
+        tx_bgp.router_id = "1.1.1.%d" % (i + 1)
+        tx_int = tx_bgp.ipv6_interfaces.add()
+        tx_int.ipv6_name = tx_ip.name
+        tx_peer = tx_int.peers.add(name="tx_bgp_peer%d" % i)
+        tx_peer.peer_address = "2000:%d::2" % i
+        tx_peer.as_type = "ebgp"
+        tx_peer.as_number = 65000 + i
+
+        tx_route = tx_peer.v6_routes.add(name=route_names[i])
+        tx_route.addresses.add(
+            address="3000:%d::1" % i, prefix=128, count=ROUTE_COUNT, step=1
+        )
+
+        # --- rx side (mirror, single aggregate route range per peer) ---
+        rx_dev = config.devices.add(name="rx_peer%d" % i)
+        rx_eth = rx_dev.ethernets.add(name="rx_eth%d" % i)
+        rx_eth.connection.port_name = p2.name
+        rx_eth.mac = "00:20:00:00:00:%02x" % i
+        rx_ip = rx_eth.ipv6_addresses.add(name="rx_ip%d" % i)
+        rx_ip.address = "2000:%d::2" % i
+        rx_ip.gateway = "2000:%d::1" % i
+        rx_ip.prefix = 64
+
+        rx_bgp = rx_dev.bgp
+        rx_bgp.router_id = "2.2.2.%d" % (i + 1)
+        rx_int = rx_bgp.ipv6_interfaces.add()
+        rx_int.ipv6_name = rx_ip.name
+        rx_peer = rx_int.peers.add(name="rx_bgp_peer%d" % i)
+        rx_peer.peer_address = "2000:%d::1" % i
+        rx_peer.as_type = "ebgp"
+        rx_peer.as_number = 55000 + i
+
+    api.set_config(config)
+
+    # --- the compaction precondition: all N ranges resolve to ONE node ------- #
+    # (This is what makes the subset withdraw exercise the compacted path.)
+    xpaths = {api.ixn_routes.get(n).xpath for n in route_names}
+    assert "" not in xpaths, (
+        "a compacted IPv6 member resolved to an empty xpath (Defect B): %s"
+        % {n: api.ixn_routes.get(n).xpath for n in route_names}
+    )
+    assert len(xpaths) == 1, (
+        "expected all %d identical IPv6 ranges to compact into one node, "
+        "got xpaths: %s" % (PEER_COUNT, xpaths)
+    )
+    rep_xpath = xpaths.pop()
+    indices = sorted(api.ixn_routes.get(n).index for n in route_names)
+    assert indices == list(range(PEER_COUNT)), (
+        "compacted members must carry a unique index in [0, N): got %s"
+        % indices
+    )
+
+    # --- start protocols and wait for every session up ----------------------- #
+    ps = api.control_state()
+    ps.choice = ps.PROTOCOL
+    ps.protocol.choice = ps.protocol.ALL
+    ps.protocol.all.state = ps.protocol.all.START
+    res = api.set_control_state(ps)
+    assert len(res.warnings) == 0, res.warnings
+
+    def _all_sessions_up():
+        req = api.metrics_request()
+        req.bgpv6.peer_names = []
+        metrics = api.get_metrics(req).bgpv6_metrics
+        return len(metrics) > 0 and all(
+            m.session_state == "up" for m in metrics
+        )
+
+    utils.wait_for(_all_sessions_up, "all BGPv6 sessions up")
+
+    # --- the customer ask: withdraw a SUBSET by list of names ---------------- #
+    withdraw_subset = [route_names[1], route_names[2]]   # 2 of N, >= 2 names
+    keep_subset = [route_names[0], route_names[3]]
+
+    cs = api.control_state()
+    cs.choice = cs.PROTOCOL
+    cs.protocol.choice = cs.protocol.ROUTE
+    cs.protocol.route.names = withdraw_subset
+    cs.protocol.route.state = cs.protocol.route.WITHDRAW
+    # Pre-fix this raised `KeyError` in Ngpf.set_route_state; it must not now.
+    res = api.set_control_state(cs)
+    assert len(res.warnings) == 0, res.warnings
+
+    # Only the two requested instances of the compacted node are inactive.
+    active = api.ngpf.select_properties(rep_xpath, properties=["active"])[
+        "active"
+    ]["values"]
+    assert len(active) == PEER_COUNT
+    for name in withdraw_subset:
+        idx = api.ixn_routes.get(name).index
+        assert active[idx] == "false", (
+            "instance %d (%s) should be withdrawn" % (idx, name)
+        )
+    for name in keep_subset:
+        idx = api.ixn_routes.get(name).index
+        assert active[idx] == "true", (
+            "instance %d (%s) must remain advertised" % (idx, name)
+        )
+
+    # --- advertise the same subset back: every instance restored ------------- #
+    cs = api.control_state()
+    cs.choice = cs.PROTOCOL
+    cs.protocol.choice = cs.protocol.ROUTE
+    cs.protocol.route.names = withdraw_subset
+    cs.protocol.route.state = cs.protocol.route.ADVERTISE
+    res = api.set_control_state(cs)
+    assert len(res.warnings) == 0, res.warnings
+
+    active = api.ngpf.select_properties(rep_xpath, properties=["active"])[
+        "active"
+    ]["values"]
+    assert all(v == "true" for v in active), (
+        "all instances should be advertised after re-advertise: %s" % active
+    )
+
+    api.set_config(api.config())
+
+
+if __name__ == "__main__":
+    pytest.main(["-vv", "-s", __file__])


### PR DESCRIPTION
**Problem**
When N structurally-identical IPv6 BGP route ranges are configured — one per device-group instance with a multiplier > 1 — the compactor merges them into a single multiplied IxNetwork node. Two independent defects existed in the code path that handles per-name route state operations (advertise / withdraw / flap) on such compacted nodes.

**Tests**
**[test_ipv6_route_compaction.py]** — 6 hardware-free unit tests:

test_set_route_state_subset_does_not_raise_keyerror — subset (list) withdraw on a compacted node raises no [KeyError]
test_set_route_state_single_name_still_works — single-name withdraw unchanged
test_set_route_state_full_list_withdraws_all_instances — full-list withdraw flips every instance
test_set_scalable_ipv6_members_inherit_representative_xpath — every compacted member resolves to the representative node with a unique index in [0, N)
test_set_scalable_no_regression_for_identical_keysets — identical-keyset (IPv4-style) members still registered correctly
test_set_scalable_preserves_foreign_object_with_usable_xpath — cross-type clobber of [ixn_objects] is still prevented
**[test_ipv6_route_withdraw.py]**— end-to-end hardware test: N identical eBGP peers, one IPv6 route range each, all compacted into one node; verifies that a named subset can be withdrawn and re-advertised, and that only the targeted instances change state.









